### PR TITLE
fix: playlist height calc

### DIFF
--- a/src/components/Playlist/hooks/usePlaylistPaginated.ts
+++ b/src/components/Playlist/hooks/usePlaylistPaginated.ts
@@ -41,7 +41,7 @@ export default (playlist: NoxMedia.Playlist): UsePlaylistP => {
     (state) => state.playlistShouldReRender,
   );
   const [page, setPage] = useState(0);
-  const [songInfoHeight, setSongInfoHeight] = useState(40);
+  const [songInfoHeight, setSongInfoHeight] = useState(0);
   const [defaultRowsPerPage, setDefaultRowsPerPage] = useState(calcRowPage());
   const [rowsPerPage, setRowsPerPage] = useState(defaultRowsPerPage);
 
@@ -89,7 +89,7 @@ export default (playlist: NoxMedia.Playlist): UsePlaylistP => {
   };
 
   useEffect(() => {
-    updateRowHeight(songInfoHeight);
+    songInfoHeight !== 0 && updateRowHeight(songInfoHeight);
     performSearch('');
     primePageToCurrentPlaying(true, playlist.songList);
   }, [playlist.id]);

--- a/src/hooks/usePlayback.ts
+++ b/src/hooks/usePlayback.ts
@@ -67,7 +67,10 @@ export default () => {
 
   const musicSrcParser = async (v: NoxMedia.Song) => {
     try {
-      const resolvedUrl = await fetchPlayUrlPromise({ song: v });
+      const resolvedUrl = await fetchPlayUrlPromise({
+        song: v,
+        noBiliR128Gain: playerSetting.noBiliR128Gain,
+      });
       if (resolvedUrl.url === DEFAULT_NULL_URL) {
         throw new Error('resolve failed');
       }


### PR DESCRIPTION
for some browsers updateRowHeight in useEffect is called AFTER it was externally called in songlist.ts, while some dont call it at all. for now just add an if to prevent the first updateRowHeight on init
closes #141 